### PR TITLE
Exclude marked scopes from super search

### DIFF
--- a/app/services/global_autocomplete.rb
+++ b/app/services/global_autocomplete.rb
@@ -18,13 +18,9 @@ class GlobalAutocomplete
   def global_super_search_result
     scopes = search_scopes.select{ |scope| scope_with_where?(scope) }
     results = scopes.map do |scope|
-      start_time = Time.current
-      result = autocomplete_result(scope)
-      end_time = Time.current
-      puts "#{end_time - start_time} seconds for #{scope[:name]}."
-      result
+      autocomplete_result(scope) unless scope[:super_search_exclude]
     end
-    results = results.flatten
+    results = results.compact.flatten
     results.uniq{ |result| [result[:model_name], result[:id]] }
   end
 

--- a/spec/services/global_autocomplete_spec.rb
+++ b/spec/services/global_autocomplete_spec.rb
@@ -108,6 +108,16 @@ RSpec.describe GlobalAutocomplete, type: :service do
       records = result.map { |item| { id: item[:id], model_name: item[:model_name] } }
       expect(records.uniq.length).to eq(records.length)
     end
+
+    context 'super_search_exclude' do
+      it 'excludes scopes with super_search_exclude marked true' do
+        scopes = search_scopes.dup
+        scopes[3][:super_search_exclude] = true
+        auto_complete = GlobalAutocomplete.new(params, scopes, user)
+        result = auto_complete.global_super_search_result
+        expect(result.count).to eq(1)
+      end
+    end
   end
 
   describe '#get_columns_values' do


### PR DESCRIPTION
Exclude scope from super search if it has `super_search_exclude` set to true. 