### PR TITLE
Display humanized model name instead of description

### DIFF
--- a/app/assets/javascripts/rad_common/rad_common.js.coffee
+++ b/app/assets/javascripts/rad_common/rad_common.js.coffee
@@ -28,7 +28,7 @@ $ ->
 
       if item.scope_description != undefined && $('.super_search').val() == '1'
         tr = $("<tr>")
-        tr.append("<td class='search-scope-description'>" + item.scope_description + "</td>")
+        tr.append("<td class='search-scope-model-name'>" + humanize(item.model_name) + "</td>")
       tr.appendTo(table)
       table.appendTo(ul)
       table
@@ -68,3 +68,6 @@ $ ->
 
   if $('.read-more').length
     $('.read-more').readmore( { speed: 75, moreLink: "<a class='btn btn-primary btn-xs read-more-btn more-btn' href='#'><div>Read more</div></a>", lessLink: "<a class='btn btn-primary btn-xs read-more-btn close-btn' href='#'><div>Close</div></a>" } )
+
+  humanize = (string) ->
+    string[0].toUpperCase() + string.substring(1).replace(/([a-z])(?=[A-Z])/g, "$1 ")

--- a/app/assets/stylesheets/rad_common/rad_common.css
+++ b/app/assets/stylesheets/rad_common/rad_common.css
@@ -80,7 +80,7 @@
   text-transform: capitalize;
   color: #7A7A7A;
 }
-.search-scope-description {
+.search-scope-model-name {
   color: #7A7A7A;
   font-size: 10px;
 }


### PR DESCRIPTION
Replacing the scope description with the model name. It's humanized, so a model name of `PrescriberLocation` would display as `Prescriber Location`