### PR TITLE
Check if valid search scope exists before searching

### DIFF
--- a/app/services/global_autocomplete.rb
+++ b/app/services/global_autocomplete.rb
@@ -26,7 +26,7 @@ class GlobalAutocomplete
   end
 
   def autocomplete_result(scope)
-    return [] unless member.can_read?(klass)
+    return [] unless scope && member.can_read?(klass)
     self.current_scope = scope
     order = scope[:query_order] || 'created_at DESC'
     query = klass.where(where_query, {search: "%#{params[:term]}%"}).order(order)

--- a/spec/services/global_autocomplete_spec.rb
+++ b/spec/services/global_autocomplete_spec.rb
@@ -78,6 +78,13 @@ RSpec.describe GlobalAutocomplete, type: :service do
       end
     end
 
+    context 'invalid global_search_scope param' do
+      let(:params) { ActionController::Parameters.new({ term: term, global_search_scope: 'foobar' }) }
+      it 'returns empty array' do
+        expect(auto_complete.autocomplete_result(scope)).to eq([])
+      end
+    end
+
     context 'member cannot read class' do
       it 'returns empty array' do
         allow_any_instance_of(User).to receive(:can_read?).and_return(false)


### PR DESCRIPTION
Prevents search from returning results if scope is not in global search scopes. 