### PR TITLE
Show Data Columns Field Translation

### DIFF
--- a/app/views/layouts/_show_data_columns.html.haml
+++ b/app/views/layouts/_show_data_columns.html.haml
@@ -42,7 +42,11 @@
               %dd
           -elsif item.is_a?(Symbol)
             -value = resource.send(item)
-            %dt= item.to_s.titlecase
+            -translation = I18n.t "activerecord.attributes.#{resource.class.to_s.underscore}.#{item.to_s}"
+            -if translation.include?('translation missing')
+              %dt= item.to_s.titlecase
+            -else
+              %dt= translation
             %dd
               -if value.class.to_s == "ActiveSupport::TimeWithZone"
                 = format_datetime(value)

--- a/spec/dummy/config/locales/en.yml
+++ b/spec/dummy/config/locales/en.yml
@@ -1,2 +1,7 @@
 en:
   app_name: Demo Foo
+  activerecord:
+    attributes:
+      user:
+        mobile_phone: 'Phone number'
+

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -90,9 +90,16 @@ describe 'Users', type: :request do
       end
 
       describe 'show' do
+        before(:each) { visit user_path(user) }
         it 'should show the user' do
-          visit user_path(user)
           expect(page).to have_content user.to_s
+        end
+
+        context 'attribute translation defined in locales' do
+          it 'shows translated version of field name' do
+            expect(page).to have_content 'Phone number'
+            expect(page).not_to have_content 'Mobile phone'
+          end
         end
       end
     end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -95,10 +95,14 @@ describe 'Users', type: :request do
           expect(page).to have_content user.to_s
         end
 
+        it 'shows field names in title case' do
+          expect(page).to have_content('User Status')
+        end
+
         context 'attribute translation defined in locales' do
           it 'shows translated version of field name' do
             expect(page).to have_content 'Phone number'
-            expect(page).not_to have_content 'Mobile phone'
+            expect(page).not_to have_content 'Mobile Phone'
           end
         end
       end


### PR DESCRIPTION
Check locale translations for field name. If one exists, show that. Otherwise show the field name as is. 