### PR TITLE
Add service class for validating start/end date order

### DIFF
--- a/app/services/date_order.rb
+++ b/app/services/date_order.rb
@@ -1,0 +1,5 @@
+class DateOrder
+  def self.invalid_date_order?(start_date, end_date)
+    (start_date.present? && end_date.present?) && (start_date > end_date)
+  end
+end

--- a/spec/services/date_order_spec.rb
+++ b/spec/services/date_order_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe DateOrder, type: :service do
+  describe 'invalid_date_order' do
+    context 'nil dates' do
+      it 'is false' do
+        expect(described_class.invalid_date_order?(nil, nil)).to eq(false)
+        expect(described_class.invalid_date_order?(nil, Date.current)).to eq(false)
+        expect(described_class.invalid_date_order?(Date.current, nil)).to eq(false)
+      end
+    end
+
+    context 'start date before end date' do
+      let(:start_date) { Date.current }
+      let(:end_date) { Date.current + 1.day }
+      it 'is false' do
+        expect(described_class.invalid_date_order?(start_date, end_date)).to eq(false)
+      end
+    end
+
+    context 'start date after end date' do
+      let(:start_date) { Date.current + 1.day }
+      let(:end_date) { Date.current }
+      it 'is true' do
+        expect(described_class.invalid_date_order?(start_date, end_date)).to eq(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add a class `DateOrder` with a method `invalid_date_order?` that takes start and end date parameters. It only returns true if both dates are present and the start date is after the end date.