### PR TITLE
Allow multiple security role selection (prototype)

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -32,6 +32,7 @@ class UsersController < ApplicationController
   def update
     @user.assign_attributes(permitted_params)
     @user.approved_by = current_member
+    @user.security_roles = resolve_roles(params[:user][:security_roles])
 
     if @user.save
       flash[:success] = 'User updated.'
@@ -67,8 +68,16 @@ class UsersController < ApplicationController
       @member = @user
     end
 
+    def resolve_roles(role_ids)
+      if role_ids
+        ids = role_ids.select{ |id| id != '' }.map{ |id| id.to_i }
+        SecurityRole.where(id: ids)
+      else
+        []
+      end
+    end
+
     def permitted_params
       params.require(:user).permit(:user_status_id, :first_name, :last_name, :mobile_phone)
     end
-
 end

--- a/app/helpers/rad_common/security_role_helper.rb
+++ b/app/helpers/rad_common/security_role_helper.rb
@@ -31,5 +31,9 @@ module RadCommon
         label
       end
     end
+
+    def collection
+      SecurityRole.all.map { |role| [role.name, role.id] }
+    end
   end
 end

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -16,5 +16,8 @@
         .row
           .col-md-6= f.input :password, autocomplete: "off", input_html: {autocomplete: "off"}
           .col-md-6= f.input :password_confirmation
+        .row
+          .col-md-6= f.input :security_roles, as: :check_boxes, collection: collection, checked: @user.security_roles.ids
+
       .form-actions
         = f.button :submit, "Save", class: "btn btn-primary"


### PR DESCRIPTION
This displays the collection of security roles as checkboxes. The form is loaded with the user's security roles checked. When a role is selected and posted, the controller will parse the role ids and set the user's security groups accordingly. 