### PR TITLE
User Security Role Tests

### DIFF
--- a/app/models/concerns/radbear_user.rb
+++ b/app/models/concerns/radbear_user.rb
@@ -50,7 +50,7 @@ module RadbearUser
     end
 
     if response.body && response.body.count != 0
-      response.body || []
+      response.body
     else
       []
     end

--- a/app/models/security_roles_user.rb
+++ b/app/models/security_roles_user.rb
@@ -1,6 +1,12 @@
 class SecurityRolesUser < ApplicationRecord
   belongs_to :security_role
-  belongs_to :user, touch: true
+  belongs_to :user
+  after_create :touch_user
+  after_destroy :touch_user
 
   audited associated_with: :user
+
+  def touch_user
+    user.touch
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -35,5 +35,19 @@ describe User, type: :model do
       user.save
       expect(user.errors.full_messages.to_s).to include('Could not register authy user')
     end
+
+    it 'updates updated_at datetime when security roles are added' do
+      security_role = create(:security_role)
+      updated_at = user.updated_at
+      user.update!(security_roles: [security_role])
+      expect(user.updated_at).not_to eq(updated_at)
+    end
+
+    it 'updates updated_at datetime when security roles are removed' do
+      user = create(:user, security_roles: [create(:security_role)])
+      updated_at = user.updated_at
+      user.update!(security_roles: [])
+      expect(user.updated_at).not_to eq(updated_at)
+    end
   end
 end


### PR DESCRIPTION
- Add tests to confirm user's `updated_at` is touched when security roles are added or removed.
- Changed the `updated_at` touch functionality to use `before_create` and `after_destroy` callbacks.