### PR TITLE
Radically Intermittent Exception

### DIFF
--- a/app/models/concerns/firebase_sync.rb
+++ b/app/models/concerns/firebase_sync.rb
@@ -22,7 +22,7 @@ module FirebaseSync
     response = app.client.get(path)
 
     unless response.success?
-      raise response.body
+      raise RadicallyIntermittentException, "#{response.body}"
     end
 
     response.body

--- a/app/services/radically_intermittent_exception.rb
+++ b/app/services/radically_intermittent_exception.rb
@@ -1,0 +1,5 @@
+class RadicallyIntermittentException < StandardError
+  def initialize(message = 'HTTP request failed')
+    super
+  end
+end


### PR DESCRIPTION
- Add RadicallyIntermittentException class
- Update firebase_sync to raise RadicallyIntermittentException instead of a RuntimeError with the response body.