### PR TITLE
changed email, website, phone number to links

### DIFF
--- a/app/views/layouts/_show_data_columns.html.haml
+++ b/app/views/layouts/_show_data_columns.html.haml
@@ -60,5 +60,11 @@
                 = format_boolean(value)
               -elsif value.class.to_s == "Array"
                 = value.join(", ")
+              -elsif item.to_s == 'phone_number'
+                = link_to value, "tel:#{value}"
+              -elsif item.to_s == 'website'
+                = link_to value, "http://#{value}", target: :_blank
+              -elsif item.to_s == 'email'
+                = mail_to value
               -else
                 = value


### PR DESCRIPTION
This seems to do the trick. Clicking phone number link starts a call, website link takes you to the website, and the email link opens up native email system with a new message started with the given email in the field. 