### PR TITLE
Use proper auth for create user for invitations

### DIFF
--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -1,6 +1,5 @@
 class Users::InvitationsController < Devise::InvitationsController
-  authorize_actions_for ApplicationAuthorizer, except: %i[edit update destroy],
-                                               actions: { new: 'create', create: 'create' }
+  authorize_actions_for User, except: %i[edit update destroy], actions: { new: 'create', create: 'create' }
 
   def create
     self.resource = invite_resource


### PR DESCRIPTION
Task 28630

This will now properly authorizer by checking if user has create user authorization rather than falling back to the application authorizer which may or may not be what is desired.