### PR TITLE
Refactor app info for list of models and tables

### DIFF
--- a/app/helpers/rad_common/audits_helper.rb
+++ b/app/helpers/rad_common/audits_helper.rb
@@ -58,11 +58,7 @@ module RadCommon
     end
 
     def audit_models_to_search
-      models = ActiveRecord::Base.connection.tables.map do |model|
-        model.capitalize.singularize.camelize.safe_constantize
-      end
-
-      models.uniq.select { |model| model.respond_to?(:auditing_enabled) && model.auditing_enabled }.map(&:to_s).sort
+      RadCommon::AppInfo.new.audited_models
     end
 
     private

--- a/app/services/database_use_checker.rb
+++ b/app/services/database_use_checker.rb
@@ -17,7 +17,7 @@ class DatabaseUseChecker
     end
 
     def tables
-      ActiveRecord::Base.connection.tables - ['schema_migrations']
+      RadCommon::AppInfo.new.application_tables
     end
 
     def zero_or_one_records?(table_name)

--- a/app/services/rad_common/app_info.rb
+++ b/app/services/rad_common/app_info.rb
@@ -1,0 +1,24 @@
+module RadCommon
+  class AppInfo
+    def application_tables
+      (ActiveRecord::Base.connection.tables - exclude_tables).sort
+    end
+
+    def application_models
+      application_tables.map { |model| model.capitalize.singularize.camelize }.sort
+    end
+
+    def audited_models
+      application_models.select do |model|
+        model_class = model.safe_constantize
+        model_class.respond_to?(:auditing_enabled) && model_class.auditing_enabled
+      end
+    end
+
+    private
+
+      def exclude_tables
+        %w[active_storage_attachments active_storage_blobs ar_internal_metadata audits schema_migrations]
+      end
+  end
+end

--- a/spec/services/global_validity_spec.rb
+++ b/spec/services/global_validity_spec.rb
@@ -14,6 +14,17 @@ describe GlobalValidity, type: :service do
 
   # TODO: add tests for override model feature
 
+  describe 'models_to_check' do
+    subject { global_validity.send(:models_to_check).map(&:to_s) }
+
+    let(:models) do
+      %w[Company Division NotificationSecurityRole NotificationSetting NotificationType SecurityRole SecurityRolesUser
+         Status SystemMessage User UserStatus]
+    end
+
+    it { is_expected.to eq models }
+  end
+
   context 'with valid data' do
     let(:global_validity_check) { global_validity.run }
 
@@ -69,7 +80,7 @@ describe GlobalValidity, type: :service do
         let(:specific_query) { -> { SecurityRole.where(id: admin_security_role.id) } }
 
         before do
-          Rails.configuration.global_validity_exclude = [SecurityRole]
+          Rails.configuration.global_validity_exclude = ['SecurityRole']
           Rails.configuration.global_validity_include = [specific_query]
         end
 

--- a/spec/services/rad_common/app_info_spec.rb
+++ b/spec/services/rad_common/app_info_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe RadCommon::AppInfo, type: :service do
+  let(:service) { described_class.new }
+
+  describe 'application_tables' do
+    subject { service.application_tables }
+
+    let(:result) do
+      %w[companies divisions notification_security_roles notification_settings notification_types security_roles
+         security_roles_users statuses system_messages user_statuses users]
+    end
+
+    it { is_expected.to eq result }
+  end
+
+  describe 'application_models' do
+    subject { service.application_models }
+
+    let(:result) do
+      %w[Company Division NotificationSecurityRole NotificationSetting NotificationType SecurityRole SecurityRolesUser
+         Status SystemMessage User UserStatus]
+    end
+
+    it { is_expected.to eq result }
+  end
+
+  describe 'audited_models' do
+    subject { service.audited_models }
+
+    let(:result) do
+      %w[Company Division NotificationSecurityRole NotificationSetting SecurityRole SecurityRolesUser Status User]
+    end
+
+    it { is_expected.to eq result }
+  end
+end


### PR DESCRIPTION
Use a more robust and unified method to return application information such as the list of tables and models.