### PR TITLE
Remove Text Capitalization Transform From Global Search

### DIFF
--- a/app/assets/stylesheets/rad_common/rad_common.scss
+++ b/app/assets/stylesheets/rad_common/rad_common.scss
@@ -120,7 +120,6 @@ trix-editor {
 
 .search-column-value {
   float: right;
-  text-transform: capitalize;
   color: #7A7A7A;
 }
 


### PR DESCRIPTION
### Task
https://swell.radicalbear.com/tasks/34946

### Notes

It looks like this has been around for several years (project was in different repo, so papertrail ends here: https://github.com/radicalbear/rad_common/pull/2). I can't see a reason we need this, the values that should be capitalized should display fine without it