### PR TITLE
Getter method for the full name of a state given the abbreviation

### DIFF
--- a/app/services/state_options.rb
+++ b/app/services/state_options.rb
@@ -74,6 +74,12 @@ class StateOptions
       options.sample.first
     end
 
+    def full_name(abbreviation)
+      return unless valid?(abbreviation)
+
+      active_states.invert[abbreviation]
+    end
+
     private
 
       def active_states

--- a/spec/services/state_options_spec.rb
+++ b/spec/services/state_options_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe StateOptions, type: :service do
+
+  describe '.full_name' do
+    subject { described_class.full_name(abbreviation) }
+
+    context 'when a valid state abbreviation is provided' do
+      let(:abbreviation) { 'FL' }
+
+      it 'returns the full name of the state' do
+        expect(subject).to eq 'Florida'
+      end
+    end
+
+    context 'when an invalid state abbreviation is provided' do
+      let(:abbreviation) { 'F1' }
+
+      it 'returns nil' do
+        expect(subject).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/state_options_spec.rb
+++ b/spec/services/state_options_spec.rb
@@ -1,15 +1,14 @@
 require 'rails_helper'
 
 describe StateOptions, type: :service do
-
   describe '.full_name' do
-    subject { described_class.full_name(abbreviation) }
+    subject(:full_name) { described_class.full_name(abbreviation) }
 
     context 'when a valid state abbreviation is provided' do
       let(:abbreviation) { 'FL' }
 
       it 'returns the full name of the state' do
-        expect(subject).to eq 'Florida'
+        expect(full_name).to eq 'Florida'
       end
     end
 
@@ -17,7 +16,7 @@ describe StateOptions, type: :service do
       let(:abbreviation) { 'F1' }
 
       it 'returns nil' do
-        expect(subject).to be_nil
+        expect(full_name).to be_nil
       end
     end
   end


### PR DESCRIPTION
Simple getter method to grab the full name of a state given the abbreviation.


Usage: 
```ruby

StateOptions.full_name('FL') # returns 'Florida'

```