### PR TITLE
Global search performance enhancement

### DIFF
--- a/app/services/global_search.rb
+++ b/app/services/global_search.rb
@@ -40,6 +40,6 @@ class GlobalSearch
     end
 
     def no_records?(scope)
-      Pundit.policy_scope!(current_user, scope[:model].constantize).count.zero?
+      Pundit.policy_scope!(current_user, scope[:model].constantize).none?
     end
 end


### PR DESCRIPTION
Make global search check for record existence with `none?` rather than `count.zero?`

I saw a huge performance improvement on an app with a large db with this one simple modification, passing it along upstream.
This method appears to be called for every search scope in the global search feature which is rendered in the internal navbar, so it makes a huge impact on system performance during business hours and page load speeds